### PR TITLE
Check for senttime flag in protocol header

### DIFF
--- a/enet.lua
+++ b/enet.lua
@@ -170,9 +170,14 @@ function p_enet.dissector(buf, pkt, root)
     
     -- Read the protocol header
     subtree:add(pf_protoheader_peerid, buf(i, 2), buf(i, 2):uint())
+    includes_senttime = bit.band(buf(i, 2):uint(), 0x8000)
     i = i + 2
-    subtree:add(pf_protoheader_senttime, buf(i, 2), buf(i, 2):uint())
-    i = i + 2
+    
+    -- Check if protocol header includes senttime
+    if includes_senttime ~= 0 then
+        subtree:add(pf_protoheader_senttime, buf(i, 2), buf(i, 2):uint())
+        i = i + 2
+    end
     
     -- Read the command header
     command = buf(i, 1):uint()


### PR DESCRIPTION
The protocol header sometimes doesn't include senttime, such as in some acks. The flag is 1 << 15. There are also some other potential problems related to this that are not resolved here, such as compression being optionally specified with flag 1 << 14 as well.

For reference, see https://github.com/cgutman/enet/blob/moonlight/protocol.c#L1018
